### PR TITLE
MAINT: changes to address test failures from python 3.9 update

### DIFF
--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -835,7 +835,7 @@ def _maz_score(metadata, predicted, column, group_by, control):
     # calculate maturity and MAZ scores in all samples
     maturity_scores = []
     maz_scores = []
-    for i, v in metadata[predicted].iteritems():
+    for i, v in metadata[predicted].items():
         _median, _std = medians[metadata.loc[i][column]]
         maturity = v - _median
         maturity_scores.append(maturity)

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -825,7 +825,8 @@ class TestLongitudinal(TestPluginBase):
     def test_first_differences_taxa(self):
         exp = pd.read_csv(self.get_data_path(
             'ecam-taxa-first-differences.tsv'),
-            sep='\t', squeeze=True, index_col=0)
+            sep='\t', index_col=0)
+        exp = exp.squeeze('columns')
         obs = first_differences(
             metadata=self.md_ecam_fp, state_column='month',
             individual_id_column='studyid',
@@ -945,7 +946,8 @@ class TestLongitudinal(TestPluginBase):
 
     def test_first_distances_ecam(self):
         exp = pd.read_csv(self.get_data_path(
-            'ecam-first-distances.tsv'), sep='\t', squeeze=True, index_col=0)
+            'ecam-first-distances.tsv'), sep='\t', index_col=0)
+        exp = exp.squeeze('columns')
         obs = first_distances(
             distance_matrix=self.md_ecam_dm, metadata=self.md_ecam_fp,
             state_column='month', individual_id_column='studyid',
@@ -1030,8 +1032,9 @@ class TestLongitudinal(TestPluginBase):
             feature_count=10)
         maz = pd.to_numeric(res[5].view(pd.Series))
         exp_maz = pd.read_csv(
-            self.get_data_path('maz.tsv'), sep='\t', squeeze=True, index_col=0,
+            self.get_data_path('maz.tsv'), sep='\t', index_col=0,
             header=0)
+        exp_maz = exp_maz.squeeze('columns')
         pdt.assert_series_equal(
             maz, exp_maz, check_dtype=False, check_index_type=False,
             check_series_type=False, check_names=False)


### PR DESCRIPTION
depends on q2-sample-classifier [PR #233](https://github.com/qiime2/q2-sample-classifier/pull/233)
also requires seaborn=0.12.2